### PR TITLE
(deprecated) 소나큐브 에러 대비 유저(nginx-user) 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,43 @@
 FROM alpine:3.22.0
 
+# (1) 필요한 nginx, nginx 설정 변경 모듈 다운로드
 RUN apk update \
  && apk add --no-cache \
   nginx="~1.28.0" \
   nginx-mod-http-headers-more
 
+# (2) 설정 파일 COPY
 COPY ./nginx.conf /etc/nginx/nginx.conf
 # default.conf, Html 파일 - 테스트를 위한 기본 설정만 적용
 COPY ./default.conf /etc/nginx/conf.d/default.conf
 COPY ./html /usr/share/nginx/html
 
-# 로컬 테스트 시 활성화
+# (3) nginx 실행 전용 비루트 사용자/그룹 생성
+RUN addgroup -g 1000 nginx-user \
+ && adduser -u 1000 -G nginx-user -s /sbin/nologin -D nginx-user
+
+# (4) 설정파일·웹루트 디렉터리 소유권을 새 사용자로 변경
+RUN mkdir -p \
+      /var/lib/nginx/logs \
+      /var/lib/nginx/tmp/client_body \
+      /var/run/nginx \
+    && chown -R nginx-user:nginx-user /etc/nginx \
+    && chown -R nginx-user:nginx-user /var/lib/nginx/logs \
+    && chown -R nginx-user:nginx-user /usr/share/nginx/html \
+    && chown -R nginx-user:nginx-user /var/lib/nginx \
+    && chown -R nginx-user:nginx-user /var/run/nginx
+
+# (5) 포트 80 비루트 사용자 권한에 맞춰서 Alpine 용 패키지인 libcap 설치 후
+# – 포트 번호 1~1023(“privileged ports”) 에는 루트 권한이 있어야만 bind 할 수 있습니다.
+# – USER nginx-user 로 nginx를 실행하면, 기본적으로 nginx-user 유저는 80번 포트를 열 권한이 없습니다.
+# – cap_net_bind_service 라는 “비-루트 사용자도 privileged port를 바인딩할 수 있는” 커널 능력(capability) 을 nginx 실행파일에 부여
+# – 이렇게 하면 nginx 프로세스가 실제로는 nginx-user(UID=1000) 권한으로 실행되면서도, 80번 포트에 문제없이 바인딩 할 수 있습니다.
+RUN apk add --no-cache libcap \
+ && setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx
+
+# (6) 컨테이너 실행 시점에 nginx를 nginx-user 사용자로 띄우도록 변경
+USER nginx-user
+
+# (7) 로컬 테스트 시 활성화
 # EXPOSE 80
 # CMD ["nginx", "-g", "daemon off;"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -4,12 +4,15 @@
 
 load_module /usr/lib/nginx/modules/ngx_http_headers_more_filter_module.so;
 
-user  nginx;
+# 컨테이너 시작 시 이미 Dockerfile 에 정의한 USER nginx-user 로 실행 권한을 제어하기 때문에, 아래 user 설정은 필요 없음
+# user  nginx;
 worker_processes  auto;
 
 # error_log  /var/log/nginx/error.log notice;
 error_log  /dev/stdout notice;
-pid        /var/run/nginx.pid;
+# NGINX 마스터 프로세스의 PID(P​rocess ID)를 기록할 파일 위치를 지정하는 역할
+# 기본적으로 /var/run 디렉터리는 루트 소유이므로 하위 디렉토리를 만들어 사용
+pid        /var/run/nginx/nginx.pid;
 
 
 events {


### PR DESCRIPTION
// deprecated

소나큐브 에러를 해결하기 위해 진행하였으나,
유저는 nginx-server-header-removed 프로젝트 내에서가 아닌, 각 프로젝트에서 user 를 설정해줘야하는 부분이어서,
다음 PR 에서 해당 내용 롤백 시켰습니다.
<img width="954" alt="image" src="https://github.com/user-attachments/assets/89bf06f6-954e-4394-ba00-29865dadcdb5" />

---
root 권한이 아닌 nginx-user 라는 이름을 가진 그룹과 유저를 만들어,
nginx-user 를 통해 컨테이너가 실행되도록 하였습니다.

nginx-user 에 설정을 위해 접근해야하는 폴더에 권한을 부여하고,
pid 파일 경로는 루트 소유인 /var/run 이 아닌 서브디렉토리 만들어 /var/run/nginx 로 설정하였습니다.

<img width="513" alt="image" src="https://github.com/user-attachments/assets/44d0f654-fc3d-43b0-a724-2be1571b05f6" />

첨부사진은 로컬에서 nginx-server-header-removed 이미지 생성 후 컨테이너를 실행하여,
id 와 whoami 명령어를 통해 현재 유저를 확인하였고,
pid 또한 /var/run/nginx/nginx.pid 에서 확인 가능했습니다.